### PR TITLE
Update logprobs demo to GPT-5 family

### DIFF
--- a/src/app/(marketing)/projects/logprobs/chatbot.tsx
+++ b/src/app/(marketing)/projects/logprobs/chatbot.tsx
@@ -129,6 +129,8 @@ type ChatEntry = {
   userRequestedIncompleteAnswer: boolean;
 };
 
+type Model = "gpt-5.1" | "gpt-5" | "gpt-5-mini" | "gpt-5-nano";
+
 interface CustomizedLabelProps {
   x: number;
   y: number;
@@ -140,7 +142,7 @@ interface CustomizedLabelProps {
 export function Chatbot() {
   const initialContext = ``;
   const initialPrompt = ``;
-  const [selectedModel, setSelectedModel] = useState("gpt-3.5-turbo");
+  const [selectedModel, setSelectedModel] = useState<Model>("gpt-5.1");
   const [repeatCount, setRepeatCount] = useState("1");
   const [retrievalCount, setRetrievalCount] = useState("1");
   const [chatEntries, setChatEntries] = useState<ChatEntry[]>([]);
@@ -666,17 +668,27 @@ export function Chatbot() {
                     id="model"
                     variant="outline"
                     type="single"
-                    defaultValue="gpt-3.5-turbo"
-                    onValueChange={(value) => setSelectedModel(value)}
+                    defaultValue="gpt-5.1"
+                    onValueChange={(value) => value && setSelectedModel(value as Model)}
                   >
-                    <ToggleGroupItem value="gpt-3.5-turbo">
+                    <ToggleGroupItem value="gpt-5.1">
                       @<span className="hidden md:block">GPT</span>
-                      <span>3.5</span>
+                      <span>5.1</span>
                     </ToggleGroupItem>
-                    <ToggleGroupItem value="gpt-4">
+                    <ToggleGroupItem value="gpt-5">
                       {" "}
                       @<span className="hidden md:block">GPT</span>
-                      <span>4.0</span>
+                      <span>5.0</span>
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="gpt-5-mini">
+                      {" "}
+                      @<span className="hidden md:block">GPT</span>
+                      <span>mini</span>
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="gpt-5-nano">
+                      {" "}
+                      @<span className="hidden md:block">GPT</span>
+                      <span>nano</span>
                     </ToggleGroupItem>
                   </ToggleGroup>
 

--- a/src/app/(marketing)/projects/logprobs/intro.tsx
+++ b/src/app/(marketing)/projects/logprobs/intro.tsx
@@ -53,7 +53,7 @@ interface TokenSpan {
 }
 
 export default function Demonstration() {
-  const [selectedModel, setSelectedModel] = useState("gpt-3.5-turbo");
+  const [selectedModel, setSelectedModel] = useState("gpt-5.1");
   const [question, setQuestion] = useState("");
   const [response, setResponse] = useState("");
   const [logProbs, setLogProbs] = useState<LogProb[]>([]);
@@ -170,11 +170,13 @@ export default function Demonstration() {
                 id="model"
                 variant="outline"
                 type="single"
-                defaultValue="gpt-3.5-turbo"
-                onValueChange={(value) => setSelectedModel(value)}
+                defaultValue="gpt-5.1"
+                onValueChange={(value) => value && setSelectedModel(value)}
               >
-                <ToggleGroupItem value="gpt-3.5-turbo">@3.5</ToggleGroupItem>
-                {/* <ToggleGroupItem value="gpt-4">@4.0</ToggleGroupItem> */}
+                <ToggleGroupItem value="gpt-5.1">@5.1</ToggleGroupItem>
+                <ToggleGroupItem value="gpt-5">@5.0</ToggleGroupItem>
+                <ToggleGroupItem value="gpt-5-mini">@5-mini</ToggleGroupItem>
+                <ToggleGroupItem value="gpt-5-nano">@5-nano</ToggleGroupItem>
               </ToggleGroup>
 
               <Button onClick={handleSubmit}>

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -127,7 +127,7 @@ async function determineAccuracy(
   question: string,
   expectedAnswer: string,
   answer: string,
-  model: string = "gpt-3.5-turbo"
+  model: string = "gpt-5.1"
 ): Promise<DetermineAccuracyResult> {
   try {
     const answerRelevanceResponse = await openai.chat.completions.create({
@@ -218,7 +218,7 @@ interface ContentCompletenessCheckResult {
 async function checkContentCompleteness(
   additionalContext: string,
   question: string,
-  model: string = "gpt-3.5-turbo"
+  model: string = "gpt-5.1"
 ): Promise<ContentCompletenessCheckResult> {
   try {
     const contentCompletnessCheckResponse =
@@ -343,7 +343,7 @@ function determineRelevance(logprobs: any | undefined): RelevanceResult {
  */
 async function constructAnswer(
   messages: Message[],
-  model: string = "gpt-3.5-turbo"
+  model: string = "gpt-5.1"
 ): Promise<{ answer: string; perplexity: number }> {
   try {
     // Format the messages array to match the OpenAI API expectations


### PR DESCRIPTION
## Summary
- replace the logprobs demo model selectors with GPT-5 family options (5.1, 5, 5-mini, 5-nano)
- update the chat API defaults to use gpt-5.1 for all automated grading steps

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e162ae54832fa105661237d90cd3)